### PR TITLE
Add some differences

### DIFF
--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -307,6 +307,12 @@ where
 参考链接：
 * https://bbs.huaweicloud.com/forum/thread-0211180070242768009-1-1.html
 
+### GaussDB数值类型（numeric）不支持Infinity（正无穷）和-Infinity（负无穷）
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0202180070831076010-1-1.html
+
 
 ## GaussDB不存在的功能
 

--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -569,6 +569,13 @@ insert into BasicEntity as be1_0(id,data) values (1,'John') on conflict do nothi
 insert into BasicEntity as be1_0(id,data) values (1,'John') on conflict do nothing
 ```
 
+### 不支持 macaddr8类型
+
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0211180066801704005-1-1.html
+
 
 
 ## GaussDB已知缺陷

--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -301,6 +301,12 @@ where
 )
 ```
 
+### GaussDB NUMERIC 类型精度没PostgreSQL高
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0211180070242768009-1-1.html
+
 
 ## GaussDB不存在的功能
 


### PR DESCRIPTION
Add some differences：
1. Cannot support macaddr8 type.
2. GaussDB NUMERIC type accuracy is not as high as PostgreSQL.
3. GaussDB numeric type does not support Infinity (positive infinity) and - Infinity (negative infinity).