### PR TITLE
Add some differences

### DIFF
--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -311,6 +311,12 @@ where
 )
 ```
 
+### GaussDB NUMERIC 类型精度没PostgreSQL高
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0211180070242768009-1-1.html
+
 
 ## GaussDB不存在的功能
 

--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -317,6 +317,12 @@ where
 参考链接：
 * https://bbs.huaweicloud.com/forum/thread-0211180070242768009-1-1.html
 
+### GaussDB数值类型（numeric）不支持Infinity（正无穷）和-Infinity（负无穷）
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0202180070831076010-1-1.html
+
 
 ## GaussDB不存在的功能
 

--- a/diff-gaussdb-postgres.md
+++ b/diff-gaussdb-postgres.md
@@ -761,6 +761,13 @@ postgres=# select '1.23'::float8;
 参考链接
 *  https://bbs.huaweicloud.com/forum/thread-0204180071486749008-1-1.html?ticket=ST-8325461-ATYwrfoNhvN7d0UckaH6YC29-sso
 
+### 不支持 macaddr8类型
+
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0211180066801704005-1-1.html
+
 ## GaussDB已知缺陷
 
 ### SET LOCK_TIMEOUT提示错误


### PR DESCRIPTION
Add some differences：
1. Cannot support macaddr8 type.
2. GaussDB NUMERIC type accuracy is not as high as PostgreSQL.
3. GaussDB numeric type does not support Infinity (positive infinity) and - Infinity (negative infinity).