### PR TITLE
Fix Typo and Document bigint Handling Differences

### DIFF
--- a/docs/diff-gaussdb-postgres.md
+++ b/docs/diff-gaussdb-postgres.md
@@ -617,7 +617,7 @@ select (current_date-cast(? as date))*86400*1e9
 ```
 * 补充说明 
 ```
-产品特性，不容兼容模式有不同的行为。默认的兼容模式是内存溢出
+产品特性，不同兼容模式有不同的行为。默认的兼容模式是内存溢出
 ```
 
 ### 对结构性字段如json的某字段的更新和查询不支持
@@ -873,4 +873,26 @@ copy (select "fld_0", "fld_1", "fld_2", "fld_3", "fld_4", "fld_5", "fld_6", "fld
 final byte[][] byteArray = session.find( EntityWithDoubleByteArray.class, id ).getByteArray();
 
 java.sql.SQLFeatureNotSupportedException: Method com.huawei.gaussdb.jdbc.jdbc.PgArray.getArrayImpl(long,int,Map) is not yet implemented.
+```
+
+### bigint类型对''的处理不同
+
+* GaussDB
+数据库使用默认兼容模式A，即Oracle兼容模式，bigint类型对空字符串的处理不同。
+
+```sql
+test02=> create table testmany (a bigint, b bigint);
+CREATE TABLE
+test02=>  insert into testmany values (1, '');
+INSERT 0 1
+```
+
+* PosgreSQL
+
+```sql
+postgres=# create table testmany (a bigint, b bigint);
+CREATE TABLE
+postgres=# insert into testmany values (1, '');
+ERROR:  invalid input syntax for type bigint: ""
+LINE 1: insert into testmany values (1, '');
 ```


### PR DESCRIPTION
## Description
This PR addresses two issues:
1. Fixes a typo in the documentation (`docs/diff-gaussdb-postgres.md`) where "不容兼容模式" was corrected to "不同兼容模式".
2. Adds documentation for the different behavior of `bigint` type handling empty strings (`''`) between GaussDB and PostgreSQL.

## Changes
- **Typo Fix**: Corrected the typo in the compatibility mode description.
- **Documentation Addition**: Added a section explaining the difference in how `bigint` handles empty strings in GaussDB (Oracle compatibility mode A) versus PostgreSQL.

## Details
### Typo Fix
- File: `docs/diff-gaussdb-postgres.md`
- Line: 617
- Changed: "不容兼容模式有不同的行为" to "不同兼容模式有不同的行为"

### bigint Handling
- Added a new section to document the behavior of `bigint` with empty strings:
  - **GaussDB**: In default compatibility mode A (Oracle), inserting an empty string (`''`) into a `bigint` column is allowed and treated as a valid input.
  - **PostgreSQL**: Inserting an empty string into a `bigint` column results in an error: `invalid input syntax for type bigint: ""`.

## Testing
- Verified the typo correction in the documentation.
- Tested the `bigint` behavior in both GaussDB and PostgreSQL using the provided SQL examples:
  - GaussDB: Successfully inserted `(1, '')` into a `bigint` column.
  - PostgreSQL: Confirmed the error on inserting `(1, '')`.