### PR TITLE
PostgreSQL与GaussDB的事务隔离级别和SET SESSION AUTHORIZATION 语句不同

### DIFF
--- a/docs/diff-gaussdb-postgres.md
+++ b/docs/diff-gaussdb-postgres.md
@@ -931,3 +931,7 @@ ROLLBACK;
 ```text
 ERROR:  SET TRANSACTION ISOLATION LEVEL must be called before any query
 ```
+
+
+### PostgreSQL与GaussDB中SET SESSION AUTHORIZATION 不同
+参考链接：https://bbs.huaweicloud.com/forum/thread-0236186944607404002-1-1.html

--- a/docs/diff-gaussdb-postgres.md
+++ b/docs/diff-gaussdb-postgres.md
@@ -915,15 +915,26 @@ ROLLBACK;
 * GaussDB
 在 GaussDB 上，执行脚本不会报错，而且隔离级别会被更改：
 ```text
- isolation_level_outer 
------------------------
- repeatable read
+openGauss=# BEGIN ISOLATION LEVEL REPEATABLE READ;
+BEGIN
+openGauss=# SELECT 'Outer: ' || current_setting('transaction_isolation') AS isolation_level_outer;
+ isolation_level_outer  
+------------------------
+ Outer: repeatable read
 (1 row)
 
- isolation_level_inner 
------------------------
- serializable
+openGauss=# SAVEPOINT sp1;
+SAVEPOINT
+openGauss=# SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET
+openGauss=# SELECT 'Inner: ' || current_setting('transaction_isolation') AS isolation_level_inner;
+ isolation_level_inner  
+------------------------
+ Inner: repeatable read
 (1 row)
+
+openGauss=# ROLLBACK;
+ROLLBACK
 ```
 
 * PosgreSQL


### PR DESCRIPTION
1、嵌套事务隔离级别不同
2、PostgreSQL与GaussDB中SET SESSION AUTHORIZATION 不同