### PR TITLE
The wait_event column does not exist in the pg_stat_activity table.

### DIFF
--- a/docs/diff-gaussdb-postgres.md
+++ b/docs/diff-gaussdb-postgres.md
@@ -871,13 +871,14 @@ postgres=# select ssl from pg_stat_ssl;
 参考链接：
 * https://bbs.huaweicloud.com/forum/thread-0203192869289100046-1-1.html
 
-### pg_stat_activity 表中 backend_type、wait_event_type 字段不存在
+### pg_stat_activity 表中 backend_type、wait_event_type、wait_event 字段不存在
 
 * 补充说明
 
 参考链接：
 * https://bbs.huaweicloud.com/forum/thread-0208192878348211072-1-1.html
 * https://bbs.huaweicloud.com/forum/thread-0237192880011140049-1-1.html
+* https://bbs.huaweicloud.com/forum/thread-0243192880666906043-1-1.html
 
 
 ## PostgreSQL不存在的功能


### PR DESCRIPTION
The wait_event column does not exist in the pg_stat_activity table.