### PR TITLE
The confirmed_flush_lsn field in the pg_replication_slots table does not exist.

### DIFF
--- a/docs/diff-gaussdb-postgres.md
+++ b/docs/diff-gaussdb-postgres.md
@@ -894,5 +894,12 @@ postgres=# select ssl from pg_stat_ssl;
 参考链接：
 * https://bbs.huaweicloud.com/forum/thread-0243192956481730045-1-1.html
 
+### pg_replication_slots 表中 confirmed_flush_lsn 字段不存在
+
+* 补充说明
+
+参考链接：
+* https://bbs.huaweicloud.com/forum/thread-0251193564075283089-1-1.html
+
 
 ## PostgreSQL不存在的功能


### PR DESCRIPTION
The confirmed_flush_lsn field in the pg_replication_slots table does not exist.